### PR TITLE
vbcc configuration to Kickstart 1.3 for Windows.

### DIFF
--- a/config/kick13_win
+++ b/config/kick13_win
@@ -1,0 +1,14 @@
+-cc=vbccm68k -quiet -hunkdebug %s -o= %s %s -O=%ld -no-cpp-warn -Ibin/targets/m68k-kick13/include
+-ccv=vbccm68k -hunkdebug %s -o= %s %s -O=%ld -no-cpp-warn -Ibin/targets/m68k-kick13/include
+-as=vasmm68k_mot -quiet -Fhunk -kick1hunks -phxass -nowarn=62 %s -o %s
+-asv=vasmm68k_mot -Fhunk -kick1hunks -phxass -nowarn=62 %s -o %s
+-rm=del /F /Q %s 
+-rmv=del /F /Q %s
+-ld=vlink -bamigahunk -x -Bstatic -Cvbcc -nostdlib -Z -mrel bin/targets/m68k-kick13/lib/startup.o %s %s -Lbin/targets/m68k-kick13/lib -lvc -o %s
+-l2=vlink -bamigahunk -x -Bstatic -Cvbcc -nostdlib -Z -mrel %s %s -Lbin/targets/m68k-kick13/lib -o %s
+-ldv=vlink -bamigahunk -t -x -Bstatic -Cvbcc -nostdlib -Z -mrel bin/targets/m68k-kick13/lib/startup.o %s %s -Lbin/targets/m68k-kick13/lib -lvc -o %s
+-l2v=vlink -bamigahunk -t -x -Bstatic -Cvbcc -nostdlib -Z -mrel %s %s -Lbin/targets/m68k-kick13/lib -o %s
+-ldnodb=-s
+-ul=-l%s
+-cf=-F%s
+-ml=1000

--- a/config/kick13m_win
+++ b/config/kick13m_win
@@ -1,0 +1,14 @@
+-cc=vbccm68k -quiet -hunkdebug %s -o= %s %s -O=%ld -no-cpp-warn -Ibin/targets/m68k-kick13/include
+-ccv=vbccm68k -hunkdebug %s -o= %s %s -O=%ld -no-cpp-warn -Ibin/targets/m68k-kick13/include
+-as=vasmm68k_mot -quiet -Fhunk -kick1hunks -phxass -nowarn=62 %s -o %s
+-asv=vasmm68k_mot -Fhunk -kick1hunks -phxass -nowarn=62 %s -o %s
+-rm=del /F /Q %s
+-rmv=del /F /Q %s
+-ld=vlink -bamigahunk -x -Bstatic -Cvbcc -nostdlib -Z -mrel bin/targets/m68k-kick13/lib/minstart.o %s %s -Lbin/targets/m68k-kick13/lib -lvc -o %s
+-l2=vlink -bamigahunk -x -Bstatic -Cvbcc -nostdlib -Z -mrel %s %s -Lbin/targets/m68k-kick13/lib -o %s
+-ldv=vlink -bamigahunk -t -x -Bstatic -Cvbcc -nostdlib -Z -mrel bin/targets/m68k-kick13/lib/minstart.o %s %s -Lbin/targets/m68k-kick13/lib -lvc -o %s
+-l2v=vlink -bamigahunk -t -x -Bstatic -Cvbcc -nostdlib -Z -mrel %s %s -Lbin/targets/m68k-kick13/lib -o %s
+-ldnodb=-s
+-ul=-l%s
+-cf=-F%s
+-ml=1000

--- a/config/kick13r_win
+++ b/config/kick13r_win
@@ -1,0 +1,14 @@
+-cc=vbccm68k -quiet -hunkdebug -sd %s -o= %s %s -O=%ld -no-cpp-warn -Ibin/targets/m68k-kick13/include
+-ccv=vbccm68k -hunkdebug -sd %s -o= %s %s -O=%ld -no-cpp-warn -Ibin/targets/m68k-kick13/include
+-as=vasmm68k_mot -quiet -Fhunk -kick1hunks -phxass -nowarn=62 %s -o %s
+-asv=vasmm68k_mot -Fhunk -kick1hunks -phxass -nowarn=62 %s -o %s
+-rm=del /F /Q %s
+-rmv=del /F /Q %s
+-ld=vlink -bamigahunk -x -Bstatic -Cvbcc -nostdlib -Z -mrel bin/targets/m68k-kick13/lib/minres.o %s %s -Lbin/targets/m68k-kick13/lib -lvcs -o %s
+-l2=vlink -bamigahunk -x -Bstatic -Cvbcc -nostdlib -Z -mrel %s %s -Lbin/targets/m68k-kick13/lib -o %s
+-ldv=vlink -bamigahunk -t -x -Bstatic -Cvbcc -nostdlib -Z -mrel bin/targets/m68k-kick13/lib/minres.o %s %s -Lbin/targets/m68k-kick13/lib -lvcs -o %s
+-l2v=vlink -bamigahunk -t -x -Bstatic -Cvbcc -nostdlib -Z -mrel %s %s -Lbin/targets/m68k-kick13/lib -o %s
+-ldnodb=-s
+-ul=-l%s
+-cf=-F%s
+-ml=1000


### PR DESCRIPTION
Configuration files to use vbcc with Kickstart 1.3 on Windows.